### PR TITLE
Sending contentType along with fileName when retrieving signingUrl

### DIFF
--- a/s3upload.js
+++ b/s3upload.js
@@ -60,7 +60,7 @@ S3Upload.prototype.createCORSRequest = function(method, url) {
 S3Upload.prototype.executeOnSignedUrl = function(file, callback) {
     var xhr = new XMLHttpRequest();
     var fileName = file.name.replace(/\s+/g, "_");
-    xhr.open('GET', this.signingUrl + '?objectName=' + fileName, true);
+    xhr.open('GET', this.signingUrl + '?objectName=' + fileName + '&contentType=' + file.type, true);
     xhr.overrideMimeType && xhr.overrideMimeType('text/plain; charset=x-user-defined');
     xhr.onreadystatechange = function() {
         if (xhr.readyState === 4 && xhr.status === 200) {


### PR DESCRIPTION
Probably should have sent this first, oops!
